### PR TITLE
Prevent 'Use of uninitialized value' when out is already flushed.

### DIFF
--- a/lib/Net/SFTP/Foreign.pm
+++ b/lib/Net/SFTP/Foreign.pm
@@ -777,7 +777,7 @@ sub flush {
 
     if ($dir ne 'in') { # flush out!
 	my $bout = $rfh->_bout;
-	my $len = length $$bout;
+	my $len = ($$bout) ? length $$bout : 0;
 	if ($len) {
 	    my $start;
 	    my $append = $rfh->_flag('append');


### PR DESCRIPTION
On perl 5.10.1 i get a lot of warnings when using [Rex](https://github.com/RexOps/Rex) to upload files, and it looks like I'm not the only one: RexOps/Rex#199 

```shell
Use of uninitialized value in length at /Users/djo/.plenv/versions/5.10.1/lib/perl5/site_perl/5.10.1/Net/SFTP/Foreign.pm line 758.
```

It looks like the warning is generated when there is nothing to flush or out has already been flushed.