### PR TITLE
protect against custom signal handlers

### DIFF
--- a/lib/Net/SFTP/Foreign.pm
+++ b/lib/Net/SFTP/Foreign.pm
@@ -279,6 +279,10 @@ sub disconnect {
 
     $debug and $debug & 4 and _debug("$sftp->disconnect called (ssh pid: ".($pid||'').")");
 
+    # someone might have set a custom SIGCHLD handler, which may
+    # interfere with our waitpids, let's reset it temporarily
+    local $SIG{CHLD} = 'DEFAULT';
+
     local $sftp->{_autodie};
     $sftp->_conn_lost;
 


### PR DESCRIPTION
If someone sets a SIGCHLD handler, `waitpid` may return -1 when the child ends, instead of a positive number. This will confuse `::Backend::Unix`.

Here we (locally) clear the handler, and we also narrow the check in `::Backend::Unix` to cope with a -1