### PR TITLE
Replace references to "slave" with "subprocess"

### DIFF
--- a/lib/Net/SFTP/Foreign.pm
+++ b/lib/Net/SFTP/Foreign.pm
@@ -2470,10 +2470,10 @@ sub ls {
     my $names_only = delete $opts{names_only};
     my $realpath = delete $opts{realpath};
     my $queue_size = delete $opts{queue_size};
-    my $cheap = ($names_only and !$realpath); 
+    my $cheap = ($names_only and !$realpath);
     my ($cheap_wanted, $wanted);
     if ($cheap and
-	ref $opts{wanted} eq 'Regexp' and 
+	ref $opts{wanted} eq 'Regexp' and
 	not defined $opts{no_wanted}) {
 	$cheap_wanted = delete $opts{wanted}
     }
@@ -5522,11 +5522,11 @@ are welcome!
 =item - Dirty cleanup:
 
 On some operating systems, closing the pipes used to communicate with
-the slave SSH process does not terminate it and a work around has to
-be applied. If you find that your scripts hung when the $sftp object
-gets out of scope, try setting C<$Net::SFTP::Foreign::dirty_cleanup>
-to a true value and also send me a report including the value of
-C<$^O> on your machine and the OpenSSH version.
+the SSH subprocess does not terminate it and a work around has to be
+applied. If you find that your scripts hung when the $sftp object gets
+out of scope, try setting C<$Net::SFTP::Foreign::dirty_cleanup> to a
+true value and also send me a report including the value of C<$^O> on
+your machine and the OpenSSH version.
 
 From version 0.90_18 upwards, a dirty cleanup is performed anyway when
 the SSH process does not terminate by itself in 8 seconds or less.
@@ -5540,10 +5540,10 @@ C<symlink> method will interpret its arguments in reverse order.
 
 =item - IPC::Open3 bugs on Windows
 
-On Windows the IPC::Open3 module is used to spawn the slave SSH
-process. That module has several nasty bugs (related to STDIN, STDOUT
-and STDERR being closed or not being assigned to file descriptors 0, 1
-and 2 respectively) that will cause the connection to fail.
+On Windows the IPC::Open3 module is used to spawn the SSH subprocess.
+That module has several nasty bugs (related to STDIN, STDOUT and STDERR
+being closed or not being assigned to file descriptors 0, 1 and 2
+respectively) that will cause the connection to fail.
 
 Specifically this is known to happen under mod_perl/mod_perl2.
 

--- a/lib/Net/SFTP/Foreign.pm
+++ b/lib/Net/SFTP/Foreign.pm
@@ -2470,10 +2470,10 @@ sub ls {
     my $names_only = delete $opts{names_only};
     my $realpath = delete $opts{realpath};
     my $queue_size = delete $opts{queue_size};
-    my $cheap = ($names_only and !$realpath);
+    my $cheap = ($names_only and !$realpath); 
     my ($cheap_wanted, $wanted);
     if ($cheap and
-	ref $opts{wanted} eq 'Regexp' and
+	ref $opts{wanted} eq 'Regexp' and 
 	not defined $opts{no_wanted}) {
 	$cheap_wanted = delete $opts{wanted}
     }

--- a/lib/Net/SFTP/Foreign/Backend/Unix.pm
+++ b/lib/Net/SFTP/Foreign/Backend/Unix.pm
@@ -295,7 +295,7 @@ sub _init_transport {
                 if (waitpid($child, POSIX::WNOHANG()) > 0 or $! == Errno::ECHILD()) {
                     undef $sftp->{pid};
                     my $err = $? >> 8;
-                    $sftp->_conn_failed("SSH slave exited unexpectedly with error code $err");
+                    $sftp->_conn_failed("SSH subprocess exited unexpectedly with error code $err");
                     return;
                 }
 
@@ -367,7 +367,7 @@ sub _after_init {
     my ($backend, $sftp) = @_;
     if ($sftp->{pid} and not $sftp->error) {
         # do not propagate signals sent from the terminal to the
-        # slave SSH:
+        # SSH subprocess:
         local ($@, $!);
         eval { setpgrp($sftp->{pid}, 0) };
     }

--- a/lib/Net/SFTP/Foreign/Backend/Windows.pm
+++ b/lib/Net/SFTP/Foreign/Backend/Windows.pm
@@ -31,7 +31,7 @@ sub _open_dev_null {
     my $sftp = shift;
     my $dev_null;
     unless (open $dev_null, '>', 'NUL:') {
-	$sftp->_conn_failed("Unable to redirect stderr for slave SSH process to NUL: $!");
+	$sftp->_conn_failed("Unable to redirect stderr for SSH subprocess to NUL: $!");
 	return;
     }
     $dev_null


### PR DESCRIPTION
This is a largely cosmetic change that replaces all instances of the word "slave" with "subprocess", in both POD and printed output.

(The word is left in-place for method calls to IO::Pty objects, because that's what those methods are called, and there's little to be done for it.)

My reason for this proposed change is that the term "slave" can be a very politically or racially charged one in certain countries, including the United States (where I happen to work). When encountered unexpectedly within these contexts, the term can lead to distraction and alarm, as if an ethnic slur had popped up in a program's error message.

I therefore propose changing it here to "subprocess", which is at least as meaningful while politically neutral to any audience.

(As a real-world example: I have a client who receives email from their system's cron daemon. I recently used this library in new production code. When the program encountered an ordinary network timeout, it emailed my client with repeated warnings about an "SSH slave". This led to confusion and alarm on their part, and embarrassment on mine.)