### PR TITLE
Update Helpers.pm to correctly check file types

### DIFF
--- a/lib/Net/SFTP/Foreign/Helpers.pm
+++ b/lib/Net/SFTP/Foreign/Helpers.pm
@@ -302,9 +302,14 @@ sub _gen_converter {
     }
 }
 
-sub _is_lnk { (0120000 & shift) == 0120000 }
-sub _is_dir { (0040000 & shift) == 0040000 }
-sub _is_reg { (0100000 & shift) == 0100000 }
+use constant S_IFMT  => 0170000;
+use constant S_IFLNK => 0120000;
+use constant S_IFDIR => 0040000;
+use constant S_IFREG => 0100000;
+
+sub _is_lnk { (S_IFMT & shift) == S_IFLNK }
+sub _is_dir { (S_IFMT & shift) == S_IFDIR }
+sub _is_reg { (S_IFMT & shift) == S_IFREG }
 
 sub _file_part {
     my $path = shift;


### PR DESCRIPTION
As it stands, sub _is_dir returns TRUE for 0040000/S_IFDIR (correctly), and for 0060000/S_IFBLK and 0140000/S_IFSOCK (incorrectly)
sub _is_reg returns TRUE for 0100000/S_IFREG (correctly), and for 0120000/S_IFLNK and 0140000/S_IFSOCK (incorrectly)
Fixed to be more like https://github.com/torvalds/linux/blob/master/include/uapi/linux/stat.h